### PR TITLE
Update the reference to data.govt.nz

### DIFF
--- a/dataexamples.md
+++ b/dataexamples.md
@@ -39,8 +39,8 @@ Author Contact: @thoughtfulnz on Twitter
 
 ```
 Data Description: Wellington cycle count data
-Data URL: https://www.transportprojects.org.nz/cycle-count-data/
-Data Licence: https://www.transportprojects.org.nz/cycle-count-data/
+Data URL: https://catalogue.data.govt.nz/dataset/cycle-count-data
+Data Licence: Creative Commons Attribution 4.0 International licence
 Example Title: Processing and visualising Wellington Cycle counter data in R/RStudio
 Example Description: Some R code walking through processing and visualising cycle counter data
 Example Code URL: https://github.com/jmarshallnz/cycle_wellington


### PR DESCRIPTION
@jmarshallnz would you be open to this change to your recent example - we've added the cycle data entry on data.govt.nz

This in the long term will allow us to create a new feature on data.govt.nz that can surface a reuse examples when someone visits the dataset on data.govt.nz.

Also, we might need to set a controlled set of values for the licence eg. do we use `Creative Commons Attribution 4.0 International licence`, or `CC BY 4.0` or a URI to denote a licence?